### PR TITLE
Rename remaining polar leftovers to spheric (#72)

### DIFF
--- a/include/puara/utils.h
+++ b/include/puara/utils.h
@@ -244,15 +244,15 @@ inline double utesla_to_gauss(double reading)
  * positive z-axis.
  * See : https://en.wikipedia.org/wiki/Spherical_coordinate_system
  */
-inline Coord3D spheric_to_cartesian(Spherical polarCoords)
+inline Coord3D spheric_to_cartesian(Spherical sphericCoords)
 {
   Coord3D cartesianCoords;
 
   cartesianCoords.x
-      = polarCoords.r * cos(polarCoords.azimuth) * sin(polarCoords.elevation);
+      = sphericCoords.r * cos(sphericCoords.azimuth) * sin(sphericCoords.elevation);
   cartesianCoords.y
-      = polarCoords.r * sin(polarCoords.elevation) * sin(polarCoords.azimuth);
-  cartesianCoords.z = polarCoords.r * cos(polarCoords.elevation);
+      = sphericCoords.r * sin(sphericCoords.elevation) * sin(sphericCoords.azimuth);
+  cartesianCoords.z = sphericCoords.r * cos(sphericCoords.elevation);
 
   return cartesianCoords;
 }

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -76,7 +76,7 @@ TEST_CASE("unit conversion helpers", "[utils]")
     REQUIRE(tesla_to_gauss(1.0) == Approx(10000.0));
 }
 
-TEST_CASE("polar_to_cartesian and cartesian_to_polar round trip", "[utils]")
+TEST_CASE("spheric_to_cartesian and cartesian_to_spheric round trip", "[utils]")
 {
     using namespace puara_gestures::utils::convert;
 


### PR DESCRIPTION
Cosmetic follow-up to the polar->spheric conversion rename flagged in #72:

- `spheric_to_cartesian` parameter `polarCoords` -> `sphericCoords`
- test-case title updated to `spheric_to_cartesian and cartesian_to_spheric round trip`

Behavior unchanged. Closes #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)