### PR TITLE
feat: add SchmittTrigger (hysteresis gate) utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The `include/puara/utils` folder contains small helpers for sensor and data proc
 - `maprange.h` — scale one numeric range into another
 - `smooth.h` — moving average smoothing
 - `threshold.h` — clamp values inside a range
+- `schmitttrigger.h` — two-threshold hysteresis gate for chatter-free on/off
 - `wrap.h` — angle wrapping utilities
 - `discretizer.h` — detect value changes
 - `circularbuffer.h` — fixed-size history storage

--- a/examples/arduino/utils/schmitttrigger/schmitttrigger.ino
+++ b/examples/arduino/utils/schmitttrigger/schmitttrigger.ino
@@ -1,0 +1,42 @@
+// Puara Gestures - Schmitt trigger (hysteresis gate) example
+// Turns a noisy analog signal into a clean on/off state without chatter
+// using the puara_gestures::utils::SchmittTrigger helper.
+//
+// A single threshold flickers when a noisy signal hovers around it. The
+// Schmitt trigger switches ON only when the input rises to `high`, and OFF
+// only when it falls to `low`; between the two it holds, so noise in that
+// band cannot make it chatter.
+//
+// Open the Arduino Serial Plotter to see the raw signal and the gate state.
+
+#include <Arduino.h>
+#include <boost-embedded-190.h>
+#include <puara-gestures.h>
+
+#define SENSOR_PIN A0
+
+// low = 300, high = 700 (raw ADC counts)
+puara_gestures::utils::SchmittTrigger gate{300.0, 700.0};
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("raw,state");
+}
+
+void loop() {
+  double raw = analogRead(SENSOR_PIN);
+  bool on = gate.update(raw);
+
+  // rose / fell are true only on the loop where the gate switched.
+  if (gate.rose) {
+    // e.g. noteOn();
+  }
+  if (gate.fell) {
+    // e.g. noteOff();
+  }
+
+  Serial.print(raw);             Serial.print(",");
+  Serial.println(on ? 1000 : 0); // scaled so the state is visible on the plot
+
+  delay(10);  // ~100 Hz
+}

--- a/include/puara/utils.h
+++ b/include/puara/utils.h
@@ -27,6 +27,7 @@
 #include <puara/utils/leakyintegrator.h>
 #include <puara/utils/maprange.h>
 #include <puara/utils/rollingminmax.h>
+#include <puara/utils/schmitttrigger.h>
 #include <puara/utils/smooth.h>
 #include <puara/utils/threshold.h>
 #include <puara/utils/wrap.h>

--- a/include/puara/utils/schmitttrigger.h
+++ b/include/puara/utils/schmitttrigger.h
@@ -1,0 +1,108 @@
+/**
+* @file schmitttrigger.h
+* @brief Hysteresis gate (Schmitt trigger): chatter-free on/off from a noisy signal.
+* @see https://github.com/Puara/puara-gestures
+* @author Société des Arts Technologiques (SAT) - https://sat.qc.ca
+* @author Input Devices and Music Interaction Laboratory (IDMIL) - https://www.idmil.org
+* @author Edu Meneses (2024) - https://www.edumeneses.com
+*/
+#pragma once
+
+namespace puara_gestures::utils
+{
+/**
+ * @class SchmittTrigger
+ * @brief Two-threshold gate that turns a noisy analog signal into a clean
+ * on/off state without chatter.
+ *
+ * @details
+ * A single threshold flickers on and off when a noisy signal hovers right
+ * around it. A Schmitt trigger fixes this with *hysteresis*: it switches ON
+ * only when the input rises to `high`, and back OFF only when it falls to
+ * `low`. Between the two thresholds the state is held, so noise in that band
+ * cannot make it chatter. This is the right building block for deriving a
+ * stable gate/trigger from any continuous sensor (pressure, proximity,
+ * envelope, motion energy) before feeding it to a note-on, a hold, or a
+ * state machine.
+ *
+ * `update()` returns the current boolean state and also exposes one-shot
+ * edge flags (`rose`, `fell`) for the exact call where the state changed,
+ * handy for triggering events. It keeps no timing state and uses only
+ * comparisons, so it is fully deterministic and behaves identically in an
+ * Arduino `loop()`, a thread, or an ossia score process. Header-only, no
+ * STL/Boost/allocation.
+ *
+ * Example:
+ * @code
+ *   puara_gestures::utils::SchmittTrigger gate{0.3, 0.7}; // low, high
+ *   bool on = gate.update(sensorValue());
+ *   if(gate.rose) { noteOn(); }
+ *   if(gate.fell) { noteOff(); }
+ * @endcode
+ */
+class SchmittTrigger
+{
+public:
+  /** @brief Input must fall to/below this to switch OFF. */
+  double low = 0.25;
+  /** @brief Input must rise to/above this to switch ON. */
+  double high = 0.75;
+
+  /** @brief Current gate state (true = on). */
+  bool state = false;
+  /** @brief True only on the update() call that switched the gate ON. */
+  bool rose = false;
+  /** @brief True only on the update() call that switched the gate OFF. */
+  bool fell = false;
+
+  SchmittTrigger() noexcept = default;
+  SchmittTrigger(const SchmittTrigger&) noexcept = default;
+  SchmittTrigger(SchmittTrigger&&) noexcept = default;
+  SchmittTrigger& operator=(const SchmittTrigger&) noexcept = default;
+  SchmittTrigger& operator=(SchmittTrigger&&) noexcept = default;
+
+  /**
+   * @brief Construct with explicit switching thresholds.
+   * @param lowValue Threshold to switch OFF.
+   * @param highValue Threshold to switch ON.
+   */
+  SchmittTrigger(double lowValue, double highValue) noexcept
+  : low(lowValue)
+  , high(highValue)
+  {
+  }
+
+  /**
+   * @brief Feed a new sample and update the gate.
+   * @param value Current input value.
+   * @return The gate state after this sample (true = on).
+   */
+  bool update(double value)
+  {
+    rose = false;
+    fell = false;
+    if(!state && value >= high)
+    {
+      state = true;
+      rose = true;
+    }
+    else if(state && value <= low)
+    {
+      state = false;
+      fell = true;
+    }
+    return state;
+  }
+
+  /** @brief Get the current gate state without feeding a new sample. */
+  bool current_value() const { return state; }
+
+  /** @brief Reset the gate to OFF and clear edge flags. */
+  void reset()
+  {
+    state = false;
+    rose = false;
+    fell = false;
+  }
+};
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -446,3 +446,53 @@ TEST_CASE("Unwrap continues decreasing through the negative boundary and resets 
     double restart = u.unwrap(1.0);
     REQUIRE(restart == Approx(1.0));
 }
+
+TEST_CASE("SchmittTrigger switches with hysteresis and reports edges", "[utils][schmitt]")
+{
+    SchmittTrigger gate{0.3, 0.7};  // low, high
+
+    // Starts OFF; a value between the thresholds does not switch it on.
+    REQUIRE(gate.update(0.5) == false);
+    REQUIRE(gate.rose == false);
+    REQUIRE(gate.fell == false);
+
+    // Rising to `high` switches ON and flags the rising edge once.
+    REQUIRE(gate.update(0.8) == true);
+    REQUIRE(gate.rose == true);
+    REQUIRE(gate.fell == false);
+
+    // Back in the hysteresis band: stays ON, no edge.
+    REQUIRE(gate.update(0.5) == true);
+    REQUIRE(gate.rose == false);
+    REQUIRE(gate.fell == false);
+
+    // Falling to `low` switches OFF and flags the falling edge once.
+    REQUIRE(gate.update(0.2) == false);
+    REQUIRE(gate.fell == true);
+    REQUIRE(gate.rose == false);
+
+    // In the band again: stays OFF.
+    REQUIRE(gate.update(0.5) == false);
+    REQUIRE(gate.rose == false);
+    REQUIRE(gate.fell == false);
+}
+
+TEST_CASE("SchmittTrigger rejects chatter around a single level", "[utils][schmitt]")
+{
+    SchmittTrigger gate{0.4, 0.6};
+    gate.update(0.7);  // ON
+
+    // Jitter within the hysteresis band must not toggle the state.
+    int transitions = 0;
+    double jitter[] = {0.55, 0.45, 0.58, 0.42, 0.5, 0.59, 0.41};
+    for(double v : jitter)
+    {
+        gate.update(v);
+        if(gate.rose || gate.fell)
+        {
+            transitions++;
+        }
+    }
+    REQUIRE(transitions == 0);
+    REQUIRE(gate.state == true);
+}


### PR DESCRIPTION
## Summary

Adds `puara_gestures::utils::SchmittTrigger`, a two-threshold hysteresis gate that turns a noisy analog signal into a clean on/off state **without chatter**.

A single threshold flickers when a noisy signal hovers around it. The Schmitt trigger switches ON only when the input rises to `high` and back OFF only when it falls to `low`; between the two thresholds the state is held, so noise in that band cannot toggle it. It is the right building block for deriving a stable gate/trigger from any continuous sensor (pressure, proximity, envelope, motion energy) before a note-on, a hold, or a state machine.

## API

```cpp
puara_gestures::utils::SchmittTrigger gate{0.3, 0.7}; // low, high
bool on = gate.update(sensorValue());
if (gate.rose) noteOn();   // one-shot: true only on the switch-ON call
if (gate.fell) noteOff();  // one-shot: true only on the switch-OFF call
```

- `low` / `high` — switch-off / switch-on thresholds
- `state` — current gate state; `rose`/`fell` — one-shot edge flags
- `current_value()` — read state without feeding a sample; `reset()` clears

## Conventions kept

- Header-only, `#pragma once`, `puara_gestures::utils` namespace
- No timing state, comparisons only → fully deterministic, identical in Arduino `loop()`, thread, or ossia process
- No STL/Boost/allocation

## Files

- `include/puara/utils/schmitttrigger.h`
- registered in `include/puara/utils.h`
- `examples/arduino/utils/schmitttrigger/schmitttrigger.ino`
- Catch2 tests in `tests/test_utils.cpp` (`[utils][schmitt]`)
- README utility list entry

## Testing

- SchmittTrigger: 17 assertions / 2 cases pass (hysteresis switching, edge flags, chatter rejection)
- Full utils suite: 152 assertions / 25 cases pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163cH7Znu2oYvnaP7fTEQMN