### PR TITLE
feat: add PeakDetector (local maxima/minima) utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The `include/puara/utils` folder contains small helpers for sensor and data proc
 - `leakyintegrator.h` — smooth decay and signal energy tracking
 - `maprange.h` — scale one numeric range into another
 - `smooth.h` — moving average smoothing
+- `peakdetector.h` — streaming local maxima/minima (peaks and troughs) with a noise guard
 - `threshold.h` — clamp values inside a range
 - `wrap.h` — angle wrapping utilities
 - `discretizer.h` — detect value changes

--- a/examples/arduino/utils/peakdetector/peakdetector.ino
+++ b/examples/arduino/utils/peakdetector/peakdetector.ino
@@ -1,0 +1,41 @@
+// Puara Gestures - PeakDetector example
+// Flags local maxima (peaks) and minima (troughs) in a streaming signal
+// using the puara_gestures::utils::PeakDetector helper.
+//
+// It reports the instant the signal turns around, so a continuous control
+// becomes events - a gesture reaching its extent, a bounce, an oscillation
+// cycle - without buffering the whole signal. The `delta` guard ignores
+// wiggles smaller than the given swing.
+//
+// Open the Arduino Serial Plotter to see the signal and peak/trough markers.
+
+#include <Arduino.h>
+#include <boost-embedded-190.h>
+#include <puara-gestures.h>
+
+#define SENSOR_PIN A0
+
+puara_gestures::utils::PeakDetector detector{5.0};  // ignore swings < 5 counts
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("value,peak,trough");
+}
+
+void loop() {
+  double value = analogRead(SENSOR_PIN);
+  detector.update(value);
+
+  if (detector.peak) {
+    // e.g. trigger on the peak: detector.peakValue
+  }
+  if (detector.trough) {
+    // e.g. trigger on the trough: detector.troughValue
+  }
+
+  Serial.print(value);                                Serial.print(",");
+  Serial.print(detector.peak ? detector.peakValue : 0);   Serial.print(",");
+  Serial.println(detector.trough ? detector.troughValue : 0);
+
+  delay(10);  // ~100 Hz
+}

--- a/include/puara/utils.h
+++ b/include/puara/utils.h
@@ -26,6 +26,7 @@
 #include <puara/utils/includeEigen.h>
 #include <puara/utils/leakyintegrator.h>
 #include <puara/utils/maprange.h>
+#include <puara/utils/peakdetector.h>
 #include <puara/utils/rollingminmax.h>
 #include <puara/utils/smooth.h>
 #include <puara/utils/threshold.h>

--- a/include/puara/utils/peakdetector.h
+++ b/include/puara/utils/peakdetector.h
@@ -1,0 +1,187 @@
+/**
+* @file peakdetector.h
+* @brief Detect local maxima and minima (peaks and troughs) in a streaming signal.
+* @see https://github.com/Puara/puara-gestures
+* @author Société des Arts Technologiques (SAT) - https://sat.qc.ca
+* @author Input Devices and Music Interaction Laboratory (IDMIL) - https://www.idmil.org
+* @author Edu Meneses (2024) - https://www.edumeneses.com
+*/
+#pragma once
+
+#include <cmath>
+
+namespace puara_gestures::utils
+{
+/**
+ * @class PeakDetector
+ * @brief Streaming local-extremum detector: flags peaks (local maxima) and
+ * troughs (local minima) as they pass.
+ *
+ * @details
+ * Feed a signal one sample at a time and `PeakDetector` reports the instant
+ * it turns around: a `peak` when the value stops rising and starts falling,
+ * a `trough` when it stops falling and starts rising. Useful for turning a
+ * continuous control into events — a gesture reaching its extent, a bounce,
+ * an oscillation cycle — without buffering the whole signal.
+ *
+ * Detection works on the slope sign, so a turning point is confirmed on the
+ * sample *after* the extremum (one-sample latency) and the reported
+ * `peakValue`/`troughValue` is the extremum itself. A `delta` guards against
+ * noise: the signal must move at least `delta` away from the last extremum
+ * before the opposite kind of extremum can be reported, so small wiggles do
+ * not produce spurious peaks.
+ *
+ * No timing or allocation, comparisons only, so it is fully deterministic
+ * and behaves identically in an Arduino `loop()`, a thread, or an ossia
+ * score process. Header-only, no STL/Boost.
+ *
+ * Example:
+ * @code
+ *   puara_gestures::utils::PeakDetector detector;
+ *   detector.delta = 0.05; // ignore wiggles smaller than this
+ *   detector.update(sensorValue());
+ *   if(detector.peak)   { onPeak(detector.peakValue); }
+ *   if(detector.trough) { onTrough(detector.troughValue); }
+ * @endcode
+ */
+class PeakDetector
+{
+public:
+  /** @brief Minimum swing away from the last extremum before the opposite one counts. */
+  double delta = 0.0;
+
+  /** @brief True for one update when a local maximum was just confirmed. */
+  bool peak = false;
+  /** @brief True for one update when a local minimum was just confirmed. */
+  bool trough = false;
+  /** @brief Value of the most recent peak. */
+  double peakValue = 0.0;
+  /** @brief Value of the most recent trough. */
+  double troughValue = 0.0;
+
+  PeakDetector() noexcept = default;
+  PeakDetector(const PeakDetector&) noexcept = default;
+  PeakDetector(PeakDetector&&) noexcept = default;
+  PeakDetector& operator=(const PeakDetector&) noexcept = default;
+  PeakDetector& operator=(PeakDetector&&) noexcept = default;
+
+  /**
+   * @brief Construct with an explicit noise threshold.
+   * @param deltaValue Minimum swing before the opposite extremum is reported.
+   */
+  explicit PeakDetector(double deltaValue) noexcept
+  : delta(deltaValue)
+  {
+  }
+
+  /**
+   * @brief Feed a new sample and look for a turning point.
+   * @param value Current input value.
+   * @return true if this sample confirmed a peak or a trough.
+   */
+  bool update(double value)
+  {
+    peak = false;
+    trough = false;
+
+    if(!initialized)
+    {
+      initialized = true;
+      last = value;
+      candidateMax = value;
+      candidateMin = value;
+      return false;
+    }
+
+    if(looking == Rising)
+    {
+      if(value > candidateMax)
+      {
+        candidateMax = value;
+      }
+      // Turned down by at least delta from the running max: that max was a peak.
+      if(value < candidateMax - delta)
+      {
+        peak = true;
+        peakValue = candidateMax;
+        candidateMin = value;
+        looking = Falling;
+      }
+    }
+    else if(looking == Falling)
+    {
+      if(value < candidateMin)
+      {
+        candidateMin = value;
+      }
+      // Turned up by at least delta from the running min: that min was a trough.
+      if(value > candidateMin + delta)
+      {
+        trough = true;
+        troughValue = candidateMin;
+        candidateMax = value;
+        looking = Rising;
+      }
+    }
+    else  // Unknown: pick a direction once the signal moves past delta.
+    {
+      if(value > candidateMax)
+      {
+        candidateMax = value;
+      }
+      if(value < candidateMin)
+      {
+        candidateMin = value;
+      }
+      if(value < candidateMax - delta)
+      {
+        peak = true;
+        peakValue = candidateMax;
+        candidateMin = value;
+        looking = Falling;
+      }
+      else if(value > candidateMin + delta)
+      {
+        trough = true;
+        troughValue = candidateMin;
+        candidateMax = value;
+        looking = Rising;
+      }
+    }
+
+    last = value;
+    return peak || trough;
+  }
+
+  /** @brief Get the most recent peak value. */
+  double current_value() const { return peakValue; }
+
+  /** @brief Clear all state. */
+  void reset()
+  {
+    peak = false;
+    trough = false;
+    peakValue = 0.0;
+    troughValue = 0.0;
+    initialized = false;
+    looking = Unknown;
+    last = 0.0;
+    candidateMax = 0.0;
+    candidateMin = 0.0;
+  }
+
+private:
+  enum Direction
+  {
+    Unknown,
+    Rising,
+    Falling
+  };
+
+  bool initialized = false;
+  Direction looking = Unknown;
+  double last = 0.0;
+  double candidateMax = 0.0;
+  double candidateMin = 0.0;
+};
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -446,3 +446,45 @@ TEST_CASE("Unwrap continues decreasing through the negative boundary and resets 
     double restart = u.unwrap(1.0);
     REQUIRE(restart == Approx(1.0));
 }
+
+TEST_CASE("PeakDetector finds peaks and troughs as the signal turns", "[utils][peak]")
+{
+    PeakDetector detector;  // delta 0
+
+    // Rising then falling: the top is a peak.
+    detector.update(0.0);
+    detector.update(1.0);
+    detector.update(2.0);   // running max
+    bool atPeak = detector.update(1.5);  // turned down -> peak at 2.0
+    REQUIRE(atPeak == true);
+    REQUIRE(detector.peak == true);
+    REQUIRE(detector.peakValue == Approx(2.0));
+
+    // Continue down then up: the bottom is a trough.
+    detector.update(0.5);
+    detector.update(0.0);   // running min
+    detector.update(0.8);   // turned up -> trough at 0.0
+    REQUIRE(detector.trough == true);
+    REQUIRE(detector.troughValue == Approx(0.0));
+}
+
+TEST_CASE("PeakDetector delta rejects small wiggles", "[utils][peak]")
+{
+    PeakDetector detector{1.0};  // require a swing of 1.0
+
+    detector.update(0.0);
+    detector.update(5.0);   // rising, running max 5.0
+
+    // A tiny dip (< delta) must not be reported as a peak.
+    detector.update(4.5);
+    REQUIRE(detector.peak == false);
+
+    // Resume rising: still no peak, the max just extends.
+    detector.update(6.0);
+    REQUIRE(detector.peak == false);
+
+    // A real drop past delta from the max confirms the peak at 6.0.
+    detector.update(4.0);
+    REQUIRE(detector.peak == true);
+    REQUIRE(detector.peakValue == Approx(6.0));
+}


### PR DESCRIPTION
## Summary

Adds `puara_gestures::utils::PeakDetector`, a streaming local-extremum detector. Fed one sample at a time it flags a **peak** when the signal stops rising and a **trough** when it stops falling — turning a continuous control into events (a gesture reaching its extent, a bounce, an oscillation cycle) without buffering the whole signal.

## API

```cpp
puara_gestures::utils::PeakDetector detector;
detector.delta = 0.05; // ignore wiggles smaller than this
detector.update(sensorValue());
if (detector.peak)   onPeak(detector.peakValue);
if (detector.trough) onTrough(detector.troughValue);
```

## Design note

Works on the slope sign, so a turning point is confirmed on the sample *after* the extremum (one-sample latency) and the reported `peakValue`/`troughValue` is the extremum itself. The `delta` guard requires the signal to swing at least that far from the last extremum before the opposite one is reported, rejecting noise. No timing or allocation → deterministic, identical in Arduino `loop()`, thread, or ossia process.

## Conventions kept

- Header-only, `#pragma once`, `puara_gestures::utils` namespace
- `update(double)` returning a bool, `current_value()`, `reset()`
- No STL/Boost/allocation

## Files

- `include/puara/utils/peakdetector.h`
- registered in `include/puara/utils.h`
- `examples/arduino/utils/peakdetector/peakdetector.ino`
- Catch2 tests in `tests/test_utils.cpp` (`[utils][peak]`)
- README utility list entry

## Testing

- PeakDetector: 9 assertions / 2 cases pass (peak/trough detection, delta noise rejection)
- Full utils suite: 144 assertions / 25 cases pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163cH7Znu2oYvnaP7fTEQMN