### PR TITLE
feat: add Normalizer (auto-ranging) utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The `include/puara/utils` folder contains small helpers for sensor and data proc
 - `rollingminmax.h` — sliding min/max over a short window
 - `leakyintegrator.h` — smooth decay and signal energy tracking
 - `maprange.h` — scale one numeric range into another
+- `normalizer.h` — auto-ranging normalizer: map an unknown-range signal to 0..1 from its own extremes
 - `smooth.h` — moving average smoothing
 - `threshold.h` — clamp values inside a range
 - `wrap.h` — angle wrapping utilities

--- a/examples/arduino/utils/normalizer/normalizer.ino
+++ b/examples/arduino/utils/normalizer/normalizer.ino
@@ -1,0 +1,36 @@
+// Puara Gestures - Normalizer example
+// Rescales a raw sensor to 0..1 using the min/max it has actually seen,
+// with no manual calibration, via puara_gestures::utils::Normalizer.
+//
+// Wave the sensor through its full range once and the output will span
+// 0..1. An optional decay slowly relaxes the learned range so it keeps
+// adapting; set calibrating = false to freeze it once you are happy.
+//
+// Open the Arduino Serial Plotter to compare the raw and normalized curves.
+
+#include <Arduino.h>
+#include <boost-embedded-190.h>
+#include <puara-gestures.h>
+
+#define SENSOR_PIN A0
+
+puara_gestures::utils::Normalizer norm;  // outputs 0..1
+
+void setup() {
+  Serial.begin(115200);
+
+  // norm.decay = 0.001;        // slowly forget stale extremes (0 = expand-only)
+  // norm.calibrating = false;  // freeze the learned range
+
+  Serial.println("raw,normalized");
+}
+
+void loop() {
+  double raw = analogRead(SENSOR_PIN);
+  double normalized = norm.update(raw);
+
+  Serial.print(raw);              Serial.print(",");
+  Serial.println(normalized, 4);
+
+  delay(10);  // ~100 Hz
+}

--- a/include/puara/utils.h
+++ b/include/puara/utils.h
@@ -26,6 +26,7 @@
 #include <puara/utils/includeEigen.h>
 #include <puara/utils/leakyintegrator.h>
 #include <puara/utils/maprange.h>
+#include <puara/utils/normalizer.h>
 #include <puara/utils/rollingminmax.h>
 #include <puara/utils/smooth.h>
 #include <puara/utils/threshold.h>

--- a/include/puara/utils/normalizer.h
+++ b/include/puara/utils/normalizer.h
@@ -1,0 +1,144 @@
+/**
+* @file normalizer.h
+* @brief Auto-ranging normalizer: map a signal of unknown range to [0, 1] from its own running extremes.
+* @see https://github.com/Puara/puara-gestures
+* @author Société des Arts Technologiques (SAT) - https://sat.qc.ca
+* @author Input Devices and Music Interaction Laboratory (IDMIL) - https://www.idmil.org
+* @author Edu Meneses (2024) - https://www.edumeneses.com
+*/
+#pragma once
+
+#include <cmath>
+
+namespace puara_gestures::utils
+{
+/**
+ * @class Normalizer
+ * @brief Rescales an incoming signal to a fixed output range using the
+ * min and max it has actually seen — no manual calibration.
+ *
+ * @details
+ * Every sensor has a different, often unknown, range. `Normalizer` learns it
+ * on the fly: it tracks the smallest and largest values observed and maps the
+ * current value to `[outMin, outMax]` (0..1 by default) accordingly. Drop it
+ * in front of a mapping and a raw sensor immediately spans the full control
+ * range without hard-coded limits, which is ideal for quick instrument
+ * prototyping and self-calibrating controllers.
+ *
+ * An optional `decay` in [0, 1) slowly relaxes the learned range back toward
+ * the current value each update, so stale extremes (a one-off spike, or a
+ * range that has since narrowed) fade and the mapping keeps adapting. With
+ * `decay = 0` the range only ever expands (classic peak-hold auto-range).
+ * `calibrating = false` freezes the learned range so the mapping stops
+ * adapting once you are happy with it.
+ *
+ * No timing or allocation, arithmetic only, so it is fully deterministic and
+ * behaves identically in an Arduino `loop()`, a thread, or an ossia score
+ * process. Header-only, no STL/Boost. For a windowed min/max instead of an
+ * all-time one, see @ref RollingMinMax.
+ *
+ * Example:
+ * @code
+ *   puara_gestures::utils::Normalizer norm;   // outputs 0..1
+ *   double control = norm.update(analogRead(A0));
+ * @endcode
+ */
+class Normalizer
+{
+public:
+  /** @brief Lower bound of the output range. */
+  double outMin = 0.0;
+  /** @brief Upper bound of the output range. */
+  double outMax = 1.0;
+  /** @brief Per-update relaxation of the learned range in [0, 1); 0 = expand-only. */
+  double decay = 0.0;
+  /** @brief When false, the learned min/max are frozen (stops adapting). */
+  bool calibrating = true;
+
+  /** @brief Most recent normalized output. */
+  double current_value = 0.0;
+  /** @brief Smallest input value seen while calibrating. */
+  double min = 0.0;
+  /** @brief Largest input value seen while calibrating. */
+  double max = 0.0;
+
+  Normalizer() noexcept = default;
+  Normalizer(const Normalizer&) noexcept = default;
+  Normalizer(Normalizer&&) noexcept = default;
+  Normalizer& operator=(const Normalizer&) noexcept = default;
+  Normalizer& operator=(Normalizer&&) noexcept = default;
+
+  /**
+   * @brief Construct with an explicit output range.
+   * @param outMinValue Lower bound of the output.
+   * @param outMaxValue Upper bound of the output.
+   */
+  Normalizer(double outMinValue, double outMaxValue) noexcept
+  : outMin(outMinValue)
+  , outMax(outMaxValue)
+  {
+  }
+
+  /**
+   * @brief Feed a new sample and get its normalized value.
+   * @param value Current raw input.
+   * @return The value mapped into [outMin, outMax].
+   */
+  double update(double value)
+  {
+    if(!initialized)
+    {
+      initialized = true;
+      min = value;
+      max = value;
+      current_value = outMin;
+      return current_value;
+    }
+
+    if(calibrating)
+    {
+      if(value < min)
+      {
+        min = value;
+      }
+      if(value > max)
+      {
+        max = value;
+      }
+      // Relax stale extremes toward the current value so the range keeps adapting.
+      if(decay > 0.0)
+      {
+        min += (value - min) * decay;
+        max += (value - max) * decay;
+      }
+    }
+
+    double span = max - min;
+    double normalized = (span > epsilon) ? (value - min) / span : 0.0;
+    if(normalized < 0.0)
+    {
+      normalized = 0.0;
+    }
+    if(normalized > 1.0)
+    {
+      normalized = 1.0;
+    }
+    current_value = outMin + normalized * (outMax - outMin);
+    return current_value;
+  }
+
+  /** @brief Clear the learned range; the next update() re-seeds it. */
+  void reset()
+  {
+    initialized = false;
+    min = 0.0;
+    max = 0.0;
+    current_value = outMin;
+  }
+
+private:
+  static constexpr double epsilon = 1e-12;
+
+  bool initialized = false;
+};
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -446,3 +446,49 @@ TEST_CASE("Unwrap continues decreasing through the negative boundary and resets 
     double restart = u.unwrap(1.0);
     REQUIRE(restart == Approx(1.0));
 }
+
+TEST_CASE("Normalizer auto-ranges a signal to 0..1", "[utils][normalizer]")
+{
+    Normalizer norm;  // outputs 0..1, expand-only
+
+    // First sample seeds the range and maps to outMin.
+    REQUIRE(norm.update(5.0) == Approx(0.0));
+
+    // A larger value becomes the new max -> maps to 1.0.
+    REQUIRE(norm.update(10.0) == Approx(1.0));
+    REQUIRE(norm.max == Approx(10.0));
+
+    // A smaller value becomes the new min -> maps to 0.0.
+    REQUIRE(norm.update(0.0) == Approx(0.0));
+    REQUIRE(norm.min == Approx(0.0));
+
+    // Now the range is [0, 10]: the midpoint maps to 0.5.
+    REQUIRE(norm.update(5.0) == Approx(0.5));
+}
+
+TEST_CASE("Normalizer honours a custom output range", "[utils][normalizer]")
+{
+    Normalizer norm{-1.0, 1.0};
+
+    norm.update(0.0);    // seed min
+    norm.update(100.0);  // seed max -> maps to outMax
+    REQUIRE(norm.current_value == Approx(1.0));
+
+    // Midpoint of [0,100] maps to the middle of [-1, 1] = 0.
+    REQUIRE(norm.update(50.0) == Approx(0.0));
+    // Bottom maps to outMin.
+    REQUIRE(norm.update(0.0) == Approx(-1.0));
+}
+
+TEST_CASE("Normalizer freezes the range when not calibrating", "[utils][normalizer]")
+{
+    Normalizer norm;
+    norm.update(0.0);
+    norm.update(10.0);  // range [0, 10]
+
+    norm.calibrating = false;
+
+    // A value beyond the frozen range is clamped, not learned.
+    REQUIRE(norm.update(20.0) == Approx(1.0));
+    REQUIRE(norm.max == Approx(10.0));  // range unchanged
+}


### PR DESCRIPTION
## Summary

Adds `puara_gestures::utils::Normalizer`, which rescales a signal of **unknown range** to a fixed output range (0..1 by default) using the min and max it has actually observed — no manual calibration. Drop it in front of a mapping and a raw sensor immediately spans the full control range, ideal for quick instrument prototyping and self-calibrating controllers.

## API

```cpp
puara_gestures::utils::Normalizer norm; // outputs 0..1
double control = norm.update(analogRead(A0));
```

- `outMin`/`outMax` — output range (constructor or fields)
- `decay` — per-update relaxation of the learned range in [0,1); `0` = expand-only peak-hold, `>0` lets stale extremes fade
- `calibrating` — set false to freeze the learned range
- `current_value`, `min`, `max`; `reset()` re-seeds

## Design note

No timing or allocation, arithmetic only → deterministic, identical in Arduino `loop()`, thread, or ossia process. Complements `RollingMinMax` (windowed) with an all-time / decaying range.

## Files

- `include/puara/utils/normalizer.h`
- registered in `include/puara/utils.h`
- `examples/arduino/utils/normalizer/normalizer.ino`
- Catch2 tests in `tests/test_utils.cpp` (`[utils][normalizer]`)
- README utility list entry

## Testing

- Normalizer: 11 assertions / 3 cases pass (auto-range to 0..1, custom output range, frozen-range mode)
- Full utils suite: 146 assertions / 26 cases pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163cH7Znu2oYvnaP7fTEQMN